### PR TITLE
Add caloric needs and BMI helpers

### DIFF
--- a/index.html
+++ b/index.html
@@ -139,6 +139,7 @@
                             <label for="patient-height" class="block text-sm font-medium text-gray-700">Altura (cm) <span class="text-red-500">*</span></label>
                             <input type="number" id="patient-height" placeholder="Ex: 175" step="1" min="1" title="Altura do paciente em centímetros (obrigatório, > 0)" class="input-field mt-1" required>
                             <p id="patient-height-error" class="error-message hidden text-sm" aria-live="polite"></p>
+                            <p id="patient-bmi-display" class="mt-1 text-gray-600 text-sm"></p>
                         </div>
                         <div class="form-group">
                             <label for="patient-condition" class="block text-sm font-medium text-gray-700">Condição Clínica <span class="text-red-500">*</span></label>
@@ -224,6 +225,14 @@
                 <fieldset class="mb-6 p-4 bg-gray-50 rounded-md border border-gray-200">
                     <legend class="text-lg font-semibold mb-3 text-gray-800 px-2">Necessidades Nutricionais</legend>
                     <div class="grid grid-cols-1 md:grid-cols-3 gap-4">
+                        <div class="form-group">
+                            <label for="caloric-needs" class="block text-sm font-medium text-gray-700">Necessidades Calóricas (kcal/kg/dia) <span class="text-red-500">*</span></label>
+                            <input type="number" id="caloric-needs" class="input-field mt-1 w-full" placeholder="Ex: 25" step="1" min="10" value="25" required>
+                        </div>
+                        <div class="form-group">
+                            <label for="caloric-needs-total" class="block text-sm font-medium text-gray-700">Total Calorias (kcal/dia)</label>
+                            <input type="number" id="caloric-needs-total" class="input-field mt-1 w-full bg-gray-200" readonly>
+                        </div>
                         <div class="form-group">
                             <label for="protein-needs" class="block text-sm font-medium text-gray-700">Proteínas (g/kg/dia) <span class="text-red-500">*</span></label>
                             <input type="number" id="protein-needs" class="input-field mt-1 w-full" placeholder="Ex: 1.2" step="0.1" min="0" title="Necessidades proteicas em g/kg/dia (obrigatório, >= 0)" value="1.2" required>

--- a/index.html
+++ b/index.html
@@ -221,9 +221,9 @@
                     </div>
                 </fieldset>
 
-                <!-- Nutritional Needs Group -->
+                <!-- Caloric Needs Group -->
                 <fieldset class="mb-6 p-4 bg-gray-50 rounded-md border border-gray-200">
-                    <legend class="text-lg font-semibold mb-3 text-gray-800 px-2">Necessidades Nutricionais</legend>
+                    <legend class="text-lg font-semibold mb-3 text-gray-800 px-2">Necessidades Calóricas</legend>
                     <div class="grid grid-cols-1 md:grid-cols-3 gap-4">
                         <div class="form-group">
                             <label for="caloric-needs" class="block text-sm font-medium text-gray-700">Necessidades Calóricas (kcal/kg/dia) <span class="text-red-500">*</span></label>
@@ -231,8 +231,16 @@
                         </div>
                         <div class="form-group">
                             <label for="caloric-needs-total" class="block text-sm font-medium text-gray-700">Total Calorias (kcal/dia)</label>
-                            <input type="number" id="caloric-needs-total" class="input-field mt-1 w-full bg-gray-200" readonly>
+                            <input type="number" id="caloric-needs-total" class="input-field mt-1 w-full bg-gray-100" readonly>
                         </div>
+                    </div>
+                    <p class="text-xs text-gray-500 mb-4" id="macro-suggestion"></p>
+                </fieldset>
+
+                <!-- Nutritional Needs Group -->
+                <fieldset class="mb-6 p-4 bg-gray-50 rounded-md border border-gray-200">
+                    <legend class="text-lg font-semibold mb-3 text-gray-800 px-2">Necessidades Nutricionais</legend>
+                    <div class="grid grid-cols-1 md:grid-cols-3 gap-4">
                         <div class="form-group">
                             <label for="protein-needs" class="block text-sm font-medium text-gray-700">Proteínas (g/kg/dia) <span class="text-red-500">*</span></label>
                             <input type="number" id="protein-needs" class="input-field mt-1 w-full" placeholder="Ex: 1.2" step="0.1" min="0" title="Necessidades proteicas em g/kg/dia (obrigatório, >= 0)" value="1.2" required>

--- a/script.js
+++ b/script.js
@@ -1,6 +1,11 @@
 // --- script.js ---
 
 /**
+ * Global application constants
+ */
+const APP_VERSION = '1.0.0';
+
+/**
  * Manages data persistence using localStorage.
  * Handles getting, saving, exporting, and importing application data.
  */
@@ -66,6 +71,7 @@ class DataManager {
 
     exportAllDataToFile() {
         const allData = {
+            version: APP_VERSION,
             patients: this.getPatients(),
             prescriptions: this.getPrescriptions(),
             solutions: this.getSolutions(),
@@ -199,6 +205,9 @@ class DataManager {
         try {
             let importedSomething = false;
             if (dataType === 'all') {
+                if (jsonData.version && jsonData.version !== APP_VERSION) {
+                    this.displayNotification(`Aviso: versão dos dados (${jsonData.version}) diferente da versão da aplicação (${APP_VERSION}).`, 'warning');
+                }
                 if (jsonData.patients && Array.isArray(jsonData.patients)) { this.savePatients(jsonData.patients); importedSomething = true; }
                 if (jsonData.prescriptions && Array.isArray(jsonData.prescriptions)) { this.savePrescriptions(jsonData.prescriptions); importedSomething = true; }
                 if (jsonData.solutions && typeof jsonData.solutions === 'object') { this.saveSolutions(jsonData.solutions); importedSomething = true; }
@@ -531,6 +540,10 @@ class NutriSoft {
         document.getElementById('add-patient-btn')?.addEventListener('click', this.addPatient);
         document.getElementById('clear-patient-form-btn')?.addEventListener('click', this.clearPatientForm);
         document.getElementById('patient-dob')?.addEventListener('change', (e) => this.updateAgeDisplay(e.target.value));
+        document.getElementById('patient-weight')?.addEventListener('input', () => this.updateBMIDisplay());
+        document.getElementById('patient-height')?.addEventListener('input', () => this.updateBMIDisplay());
+        document.getElementById('caloric-needs')?.addEventListener('input', () => this.updateCaloricNeedsTotal());
+        document.getElementById('prescription-patient')?.addEventListener('change', () => this.updateCaloricNeedsTotal());
 
         document.getElementById('calculate-formulation-btn')?.addEventListener('click', this.calculateFormulation);
         document.getElementById('save-prescription-btn')?.addEventListener('click', this.savePrescription);
@@ -1111,6 +1124,7 @@ class NutriSoft {
             fieldsToValidate.push({ id: 'patient-dob', type: 'date', message: 'Data de nascimento inválida.' }); 
         } else if (section === 'prescription') {
             fieldsToValidate.push({ id: 'prescription-patient', required: true, message: 'Selecione o doente.' });
+            fieldsToValidate.push({ id: 'caloric-needs', required: true, type: 'number', min: 10, message: 'Calorias por kg devem ser >= 10.' });
             fieldsToValidate.push({ id: 'total-volume', required: true, type: 'number', min: 1, message: 'Volume total deve ser um número válido maior que zero.' });
             fieldsToValidate.push({ id: 'protein-needs', required: true, type: 'number', min: 0, message: 'Necessidades proteicas devem ser >= 0.' });
             fieldsToValidate.push({ id: 'lipid-needs', required: true, type: 'number', min: 0, message: 'Necessidades lipídicas devem ser >= 0.' });
@@ -1225,11 +1239,50 @@ class NutriSoft {
             return '';
         }
     }
-    updateAgeDisplay(dobValue) { 
+    updateAgeDisplay(dobValue) {
         const ageDisplay = document.getElementById('patient-age-display');
         if (ageDisplay) {
             ageDisplay.textContent = this.calculateAge(dobValue);
-        } 
+        }
+    }
+
+    calculateBMI(weight, heightCm) {
+        const h = heightCm / 100;
+        if (weight > 0 && h > 0) {
+            return weight / (h * h);
+        }
+        return NaN;
+    }
+
+    updateBMIDisplay() {
+        const weight = parseFloat(document.getElementById('patient-weight')?.value);
+        const height = parseFloat(document.getElementById('patient-height')?.value);
+        const bmiDisplay = document.getElementById('patient-bmi-display');
+        if (!bmiDisplay) return;
+        const bmi = this.calculateBMI(weight, height);
+        bmiDisplay.textContent = isNaN(bmi) ? '' : `IMC: ${bmi.toFixed(1)}`;
+    }
+
+    updateCaloricNeedsTotal() {
+        const kcalPerKg = parseFloat(document.getElementById('caloric-needs')?.value);
+        const patientId = parseInt(document.getElementById('prescription-patient')?.value);
+        const patient = this.patients.find(p => p.id === patientId);
+        const weight = patient?.weight ?? 0;
+        const totalKcal = (weight > 0 && kcalPerKg > 0) ? weight * kcalPerKg : 0;
+        const totalField = document.getElementById('caloric-needs-total');
+        if (totalField) totalField.value = totalKcal ? totalKcal.toFixed(0) : '';
+
+        if (weight > 0 && totalKcal > 0) {
+            const protKcal = totalKcal * 0.18;
+            const lipKcal = totalKcal * 0.32;
+            const gluKcal = totalKcal * 0.50;
+            const protPerKg = protKcal / 4 / weight;
+            const lipPerKg = lipKcal / 9 / weight;
+            const gluRate = ((gluKcal / 3.4) * 1000) / (weight * 1440);
+            this.setInputValue('protein-needs', protPerKg.toFixed(2));
+            this.setInputValue('lipid-needs', lipPerKg.toFixed(2));
+            this.setInputValue('glucose-rate', gluRate.toFixed(2));
+        }
     }
     addPatient() { 
         console.log("NutriSoft.addPatient: Attempting to add/edit patient.");
@@ -1301,11 +1354,12 @@ class NutriSoft {
         document.getElementById('patient-weight').value = patient.weight ?? '';
         document.getElementById('patient-height').value = patient.height ?? '';
         document.getElementById('patient-condition').value = patient.condition || '';
-        document.getElementById('patient-id').value = patient.id; 
+        document.getElementById('patient-id').value = patient.id;
 
         this.updateAgeDisplay(patient.dob);
+        this.updateBMIDisplay();
         document.getElementById('patients-section')?.scrollIntoView({ behavior: 'smooth', block: 'start' });
-        document.getElementById('patient-name')?.focus(); 
+        document.getElementById('patient-name')?.focus();
     }
     deletePatient(patientId) { 
         const patient = this.patients.find(p => p.id === patientId);
@@ -1358,6 +1412,8 @@ class NutriSoft {
         }
         const ageDisplay = document.getElementById('patient-age-display');
         if (ageDisplay) ageDisplay.textContent = '';
+        const bmiDisplay = document.getElementById('patient-bmi-display');
+        if (bmiDisplay) bmiDisplay.textContent = '';
 
         if (logAction) AuditLogger.log('clearPatientForm');
     }
@@ -1839,9 +1895,13 @@ class NutriSoft {
         }
 
         try {
+            const kcalPerKg = this.getNumericInput('caloric-needs', 0, true);
+            const totalKcal = (patient.weight > 0 && kcalPerKg > 0) ? patient.weight * kcalPerKg : 0;
+
             const formulation = {
-                patient: patient, 
+                patient: patient,
                 volume: totalVolume, // Prescribed total volume
+                totalKcal: totalKcal,
                 route: administrationRoute,
                 proteins: this.calculateProteins(patient),
                 glucose: this.calculateGlucose(patient),
@@ -2344,6 +2404,9 @@ class NutriSoft {
         const patientWeight = formulation.patient?.weight ?? 0;
 
         this.setInputValue('prescription-patient', patientId);
+        const kcalPerKg = patientWeight > 0 ? (formulation.totalKcal / patientWeight) : '';
+        this.setInputValue('caloric-needs', kcalPerKg ? kcalPerKg.toFixed(0) : '');
+        this.setInputValue('caloric-needs-total', formulation.totalKcal ?? '');
         this.setInputValue('total-volume', formulation.volume);
         this.setInputValue('administration-route', formulation.route || 'central');
 
@@ -2387,6 +2450,7 @@ class NutriSoft {
         this.setInputValue('cacl2-solution', formulation.electrolytes?.calcium?.solution); 
         this.setInputValue('mgso4-solution', formulation.electrolytes?.magnesium?.solution);
         this.setInputValue('phosphorus-solution', formulation.electrolytes?.phosphorus?.solution);
+        this.updateCaloricNeedsTotal();
     }
     printPrescription(originalIndex = null) { 
         console.log("NutriSoft.printPrescription: Preparing to print. Original Index:", originalIndex);
@@ -3003,6 +3067,10 @@ document.addEventListener('DOMContentLoaded', () => {
             console.log("Initial hash is empty or '#', forcing to #patients for robust startup.");
             window.location.hash = 'patients';
         }
+
+        window.addEventListener('beforeunload', () => {
+            try { app.saveAllData(); } catch (e) { console.error('Erro ao gravar dados antes de sair:', e); }
+        });
 
     } catch (error) {
         console.error("FATAL: Error initializing NutriSoft application:", error);

--- a/script.js
+++ b/script.js
@@ -540,7 +540,10 @@ class NutriSoft {
         document.getElementById('add-patient-btn')?.addEventListener('click', this.addPatient);
         document.getElementById('clear-patient-form-btn')?.addEventListener('click', this.clearPatientForm);
         document.getElementById('patient-dob')?.addEventListener('change', (e) => this.updateAgeDisplay(e.target.value));
-        document.getElementById('patient-weight')?.addEventListener('input', () => this.updateBMIDisplay());
+        document.getElementById('patient-weight')?.addEventListener('input', () => {
+            this.updateBMIDisplay();
+            this.updateCaloricNeedsTotal();
+        });
         document.getElementById('patient-height')?.addEventListener('input', () => this.updateBMIDisplay());
         document.getElementById('caloric-needs')?.addEventListener('input', () => this.updateCaloricNeedsTotal());
         document.getElementById('prescription-patient')?.addEventListener('change', () => this.updateCaloricNeedsTotal());
@@ -1272,6 +1275,7 @@ class NutriSoft {
         const totalField = document.getElementById('caloric-needs-total');
         if (totalField) totalField.value = totalKcal ? totalKcal.toFixed(0) : '';
 
+        const macroSuggestion = document.getElementById('macro-suggestion');
         if (weight > 0 && totalKcal > 0) {
             const protKcal = totalKcal * 0.18;
             const lipKcal = totalKcal * 0.32;
@@ -1282,6 +1286,15 @@ class NutriSoft {
             this.setInputValue('protein-needs', protPerKg.toFixed(2));
             this.setInputValue('lipid-needs', lipPerKg.toFixed(2));
             this.setInputValue('glucose-rate', gluRate.toFixed(2));
+            const protG = protKcal / 4;
+            const lipG = lipKcal / 9;
+            const gluG = gluKcal / 3.4;
+            if (macroSuggestion) {
+                macroSuggestion.textContent =
+                    `Distribuição sugerida: ${protG.toFixed(1)}g proteína, ${lipG.toFixed(1)}g lípidos, ${gluG.toFixed(1)}g glicose`;
+            }
+        } else if (macroSuggestion) {
+            macroSuggestion.textContent = '';
         }
     }
     addPatient() { 

--- a/style.css
+++ b/style.css
@@ -1,4 +1,3 @@
-```css
 /* style.css - NutriSoft Custom Styles */
 
 /* --- Base & Typography --- */
@@ -303,4 +302,3 @@ body.modal-open {
         }
      }
 }
-```

--- a/style.css
+++ b/style.css
@@ -10,6 +10,11 @@ body {
     -moz-osx-font-smoothing: grayscale;
 }
 
+#macro-suggestion {
+    color: #0284c7;
+    font-weight: 500;
+}
+
 .container {
     max-width: 1280px; /* Increased max-width slightly */
     margin-left: auto;


### PR DESCRIPTION
## Summary
- add caloric need inputs in prescription form
- display patient BMI in patient form
- compute caloric totals and suggest macro distribution automatically
- show total kcal and macros when loading a prescription
- store totalKcal in formulations

## Testing
- `grep -n "\`\`\`" style.css`

------
https://chatgpt.com/codex/tasks/task_e_68415dc58c648330b8e8a486fe73566f