### PR TITLE
Add basic protocol support

### DIFF
--- a/index.html
+++ b/index.html
@@ -218,6 +218,12 @@
                             </select>
                              <p id="administration-route-error" class="error-message hidden text-sm" aria-live="polite"></p>
                         </div>
+                        <div class="form-group">
+                            <label for="prescription-protocol" class="block text-sm font-medium text-gray-700">Protocolo</label>
+                            <select id="prescription-protocol" class="input-field mt-1 w-full" title="Selecione protocolo (opcional)">
+                                <option value="">Nenhum</option>
+                            </select>
+                        </div>
                     </div>
                 </fieldset>
 

--- a/script.js
+++ b/script.js
@@ -2755,6 +2755,7 @@ class NutriSoft {
             y += lineSpacing * 2;
             doc.text(`Data Impressão: ${new Date().toLocaleString()}`, margin, y);
 
+            this.generateLabelsPage(doc, formulation, preparationNumber, patientName, prescriptionDate);
             const filename = `Prescricao_NP_${String(preparationNumber).replace(/\W/g, '')}_${patientName.replace(/\s+/g, '_')}_${new Date().toISOString().split('T')[0]}.pdf`;
             doc.save(filename);
             console.log("PDF generated:", filename);
@@ -2764,7 +2765,7 @@ class NutriSoft {
             AuditLogger.log('exportPDFError', { prepId: preparationNumber, error: error.message, stack: error.stack });
         }
     }
-    formatCompositionDetailsForPDF(formulation) { 
+    formatCompositionDetailsForPDF(formulation) {
         const details = [];
         const formatLine = (label, component, valueKey = 'volume', unit = 'ml', dp = 2) => {
              if (!component || component[valueKey] === undefined || component[valueKey] === null || (component[valueKey] === 0 && (label.toLowerCase().includes('volume') || unit ==='ml'))) return null;
@@ -2826,22 +2827,38 @@ class NutriSoft {
 
         return details.filter(line => line !== null).join('\n');
     }
-    addLabelContent(doc, formulation, startX, startY, isLipidsLabel, preparationNumber, patientName, prescriptionDate) { 
+    generateLabelsPage(doc, formulation, prepNum, patientName, prescriptionDate) {
+        const labelWidth = 90, labelHeight = 50;
+        const marginX = 10, marginY = 10, gapX = 10, gapY = 10;
+        const isTwoBags = (formulation.patient?.weight < 5 && formulation.patient?.condition === 'pediatric') || (formulation.patient?.condition === 'neonate');
+        const labels = isTwoBags ? [false, false, true, true] : [false, false, false, false];
+        doc.addPage();
+        labels.forEach((isLipids, idx) => {
+            if (idx > 0 && idx % 4 === 0) doc.addPage();
+            const col = idx % 2;
+            const row = Math.floor((idx % 4) / 2);
+            const x = marginX + col * (labelWidth + gapX);
+            const y = marginY + row * (labelHeight + gapY);
+            this.addLabelContent(doc, formulation, x, y, isLipids, prepNum, patientName, prescriptionDate);
+        });
+    }
+    addLabelContent(doc, formulation, startX, startY, isLipidsLabel, preparationNumber, patientName, prescriptionDate) {
         const labelWidth = 90; const labelHeight = 50; const padding = 5;
         const textStartX = startX + padding;
         let currentY = startY + padding;
-        const lineSpacingLabel = 4; 
+        const lineSpacingLabel = 4;
 
-        doc.setDrawColor(0); doc.rect(startX, startY, labelWidth, labelHeight); 
+        doc.setDrawColor(0); doc.setLineWidth(0.3); doc.rect(startX, startY, labelWidth, labelHeight);
 
-        doc.setFontSize(8); doc.setFont(undefined, 'italic');
-        doc.text('<<ULSSM - SG TF>>', textStartX, currentY); currentY += lineSpacingLabel * 0.8;
+        doc.setFontSize(9); doc.setFont(undefined, 'italic');
+        doc.text('ULSSM - SG TF', textStartX, currentY); currentY += lineSpacingLabel * 0.9;
 
-        doc.setFontSize(11); doc.setFont(undefined, 'bold');
-        doc.text(`#Prep: ${preparationNumber}`, textStartX, currentY); currentY += lineSpacingLabel * 1.1;
+        doc.setFontSize(12); doc.setFont(undefined, 'bold');
+        doc.text(`#Prep: ${preparationNumber}`, textStartX, currentY); currentY += lineSpacingLabel * 1.2;
 
         const maxNameWidthChars = 35; 
         const displayName = patientName.length > maxNameWidthChars ? patientName.substring(0, maxNameWidthChars) + "..." : patientName;
+        doc.setFontSize(10); doc.setFont(undefined, 'bold');
         doc.text(`Paciente: ${displayName}`, textStartX, currentY); currentY += lineSpacingLabel * 1.1;
 
         doc.setFontSize(9); doc.setFont(undefined, 'bold');
@@ -2870,6 +2887,7 @@ class NutriSoft {
             const lipidVol = (formulation.lipids?.volume??0) + (formulation.additives?.fat_soluble_vitamins?.volume??0);
             bagVol = isLipidsLabel ? lipidVol : formulation.volume - lipidVol;
         }
+        doc.setFontSize(9); doc.setFont(undefined, 'normal');
         doc.text(`Volume: ${this.formatValue(bagVol, 'ml', 0)}`, textStartX, currentY); currentY += lineSpacingLabel;
         doc.text(`Validade: (Definir conforme protocolo)`, textStartX, currentY); currentY += lineSpacingLabel;
 

--- a/script.js
+++ b/script.js
@@ -2658,105 +2658,22 @@ class NutriSoft {
             }
         }
     }
-    exportPDF(formulation, preparationMap, preparationNumber, patientName, prescriptionDate) { 
+    exportPDF(formulation, preparationMap, preparationNumber, patientName, prescriptionDate) {
         try {
             if (!window.jspdf || !window.jspdf.jsPDF) {
                 console.error("jsPDF library is not loaded. Cannot generate PDF.");
                 this.dataManager.displayNotification("Erro: Biblioteca jsPDF não carregada.", "error");
                 return;
             }
+
             const { jsPDF } = window.jspdf;
             const doc = new jsPDF({ orientation: 'p', unit: 'mm', format: 'a4' });
 
-            const pageWidth = doc.internal.pageSize.getWidth();
-            const pageHeight = doc.internal.pageSize.getHeight();
-            const margin = 10;
-            const usableWidth = pageWidth - 2 * margin;
-            let y = margin;
-            const lineSpacing = 5; 
-            const sectionSpacing = 8;
-
-            const addWrappedText = (text, x, currentY, options = {}) => {
-                const { fontSize = 10, fontStyle = 'normal', maxWidth = usableWidth, color = [0,0,0] } = options;
-                doc.setFontSize(fontSize);
-                doc.setFont(undefined, fontStyle);
-                doc.setTextColor(color[0], color[1], color[2]);
-
-                const lines = doc.splitTextToSize(text, maxWidth);
-                doc.text(lines, x, currentY);
-                return currentY + (lines.length * (fontSize * 0.352778 * 1.2)); 
-            };
-
-            doc.setFontSize(16); doc.setFont(undefined, 'bold');
-            doc.text('Prescrição de Nutrição Parentérica', pageWidth / 2, y, { align: 'center' });
-            y += lineSpacing * 2;
-
-            doc.setFontSize(10); doc.setFont(undefined, 'normal');
-            doc.text(`Número Preparação: ${preparationNumber}`, margin, y);
-            let displayDate = 'N/A';
-            try { displayDate = prescriptionDate ? new Date(prescriptionDate).toLocaleDateString() : new Date().toLocaleDateString(); } catch {}
-            doc.text(`Data Prescrição: ${displayDate}`, pageWidth - margin, y, { align: 'right' });
-            y += lineSpacing * 1.5;
-
-            doc.text(`Paciente: ${patientName || 'N/A'}`, margin, y);
-            doc.text(`Peso: ${formulation.patient?.weight ?? '?'} kg`, pageWidth - margin, y, { align: 'right' });
-            y += lineSpacing * 1.5;
-            doc.line(margin, y, pageWidth - margin, y); 
-            y += lineSpacing;
-
-
-            doc.setFontSize(12); doc.setFont(undefined, 'bold');
-            doc.text('Detalhes da Formulação:', margin, y);
-            y += lineSpacing;
-            const formulationDetailsText = this.formatCompositionDetailsForPDF(formulation);
-            y = addWrappedText(formulationDetailsText, margin, y, { fontSize: 9 });
-            y += sectionSpacing;
-
-            if (y > pageHeight - margin * 3) { doc.addPage(); y = margin; } 
-
-            doc.setFontSize(12); doc.setFont(undefined, 'bold');
-            doc.text('Mapa de Preparação (Ordem Sugerida):', margin, y);
-            y += lineSpacing;
-            y = addWrappedText(preparationMap, margin, y, { fontSize: 8.5, fontStyle: 'courier' }); 
-            y += sectionSpacing;
-
-            if (y > pageHeight - margin * 3) { doc.addPage(); y = margin; }
-
-            if (formulation.warnings?.length > 0) {
-                doc.setFontSize(12); doc.setFont(undefined, 'bold');
-                y = addWrappedText('Avisos da Formulação:', margin, y, { color: [255, 100, 0] }); 
-                y += lineSpacing * 0.5;
-                y = addWrappedText(formulation.warnings.map(w => `- ${w}`).join('\n'), margin, y, { fontSize: 9 });
-                y += sectionSpacing;
-                if (y > pageHeight - margin * 3) { doc.addPage(); y = margin; }
-            }
-
-            if (formulation.errors?.length > 0) {
-                doc.setFontSize(12); doc.setFont(undefined, 'bold');
-                y = addWrappedText('ERROS CRÍTICOS:', margin, y, { color: [255, 0, 0] }); 
-                y += lineSpacing * 0.5;
-                y = addWrappedText(formulation.errors.map(e => `- ${e}`).join('\n'), margin, y, { fontSize: 9 });
-                y += sectionSpacing;
-                if (y > pageHeight - margin * 3) { doc.addPage(); y = margin; }
-            }
-
-            y = Math.max(y, pageHeight - margin - 30); 
-            if (y > pageHeight - margin - 30) { 
-                 if (pageHeight - y < 30) { 
-                    doc.addPage(); y = margin;
-                 }
-            } else {
-                y = pageHeight - margin - 30; 
-            }
-
-            doc.setFontSize(10);
-            doc.text('Prescrito por: _________________________', margin, y);
-            doc.text('Conferido por (Farm.): _________________________', pageWidth / 2, y, {align: 'left'});
-            y += lineSpacing * 2;
-            doc.text(`Data Impressão: ${new Date().toLocaleString()}`, margin, y);
+            this.generateWorksheetPage(doc, formulation, preparationMap, preparationNumber, patientName, prescriptionDate);
 
             this.generateLabelsPage(doc, formulation, preparationNumber, patientName, prescriptionDate);
-            const filename = `Prescricao_NP_${String(preparationNumber).replace(/\W/g, '')}_${patientName.replace(/\s+/g, '_')}_${new Date().toISOString().split('T')[0]}.pdf`;
+
+            const filename = `PN_${String(preparationNumber).replace(/\W/g, '')}_${patientName.replace(/\s+/g, '_')}_${new Date().toISOString().split('T')[0]}.pdf`;
             doc.save(filename);
             console.log("PDF generated:", filename);
         } catch (error) {
@@ -2764,6 +2681,89 @@ class NutriSoft {
             this.dataManager.displayNotification(`Erro ao gerar PDF: ${error.message}. Verifique o console.`, 'error');
             AuditLogger.log('exportPDFError', { prepId: preparationNumber, error: error.message, stack: error.stack });
         }
+    }
+
+    generateWorksheetPage(doc, formulation, preparationMap, prepNumber, patientName, prescriptionDate) {
+        const pageWidth = doc.internal.pageSize.getWidth();
+        const margin = 10;
+        const usableWidth = pageWidth - margin * 2;
+        let y = margin;
+        const line = (txt, offset = 0) => { doc.text(txt, margin + offset, y); y += 5; };
+
+        doc.setFontSize(14); doc.setFont(undefined, 'bold');
+        doc.text('PARENTERAL NUTRITION SOLUTION', pageWidth / 2, y, { align: 'center' });
+        y += 7;
+
+        doc.setFontSize(9); doc.setFont(undefined, 'normal');
+        let dateStr = 'N/A';
+        try { dateStr = prescriptionDate ? new Date(prescriptionDate).toLocaleDateString() : new Date().toLocaleDateString(); } catch {}
+        line(`#Prep: ${prepNumber}`);
+        line(`Data Prescrição: ${dateStr}`);
+        line(`Paciente: ${patientName}`);
+        line(`Via: ${formulation.route === 'peripheral' ? 'Periférica' : 'Central'}`);
+
+        const patient = formulation.patient || {};
+        line(`Peso: ${this.formatValue(patient.weight, 'kg', 1)}`);
+        if (patient.height) line(`Altura: ${this.formatValue(patient.height, 'cm', 0)}`);
+        if (patient.condition) line(`Condição: ${patient.condition}`);
+
+        doc.line(margin, y, margin + usableWidth, y); y += 6;
+
+        doc.setFontSize(10); doc.setFont(undefined, 'bold');
+        line('Macronutrientes e Energia');
+
+        doc.setFontSize(9); doc.setFont(undefined, 'normal');
+        const weight = patient.weight || 0;
+        const prot = formulation.proteins || {};
+        const glu = formulation.glucose || {};
+        const lip = formulation.lipids || {};
+
+        const protKg = weight > 0 ? prot.required / weight : 0;
+        const gluKg = weight > 0 ? glu.required / weight : 0;
+        const lipKg = weight > 0 ? lip.required / weight : 0;
+        const energyProt = prot.required * 4;
+        const energyGlu = glu.required * 3.4;
+        const energyLip = lip.required * 9;
+
+        line(`Aminoácidos: ${this.formatValue(prot.required, 'g', 0)} (${this.formatValue(protKg, 'g/kg', 2)})  N: ${this.formatValue(prot.nitrogen, 'g', 2)}  kcal: ${this.formatValue(energyProt, 'kcal', 0)}`);
+        line(`Glicose: ${this.formatValue(glu.required, 'g', 0)} (${this.formatValue(gluKg, 'g/kg', 2)})  kcal: ${this.formatValue(energyGlu, 'kcal', 0)}`);
+        line(`Lípidos: ${this.formatValue(lip.required, 'g', 0)} (${this.formatValue(lipKg, 'g/kg', 2)})  kcal: ${this.formatValue(energyLip, 'kcal', 0)}`);
+        const totalEnergy = energyProt + energyGlu + energyLip;
+        line(`Energia Total Estimada: ${this.formatValue(totalEnergy, 'kcal', 0)}`);
+
+        y += 2;
+        doc.setFontSize(10); doc.setFont(undefined, 'bold');
+        line('Ingredientes da Nutrição Parentérica');
+        doc.setFontSize(9); doc.setFont(undefined, 'normal');
+        const addRow = (comp, data, unit) => {
+            if (!data) return;
+            line(`${comp}: ${this.formatValue(data.required ?? data.volume, unit)} ${data.solution ? '('+data.solution+')' : ''} → ${this.formatValue(data.volume, 'ml')}`, 0);
+        };
+        addRow('Aminoácidos', prot, 'g');
+        if (formulation.glutamine?.volume > 0) addRow('Glutamina', formulation.glutamine, 'g');
+        addRow('Glucose', glu, 'g');
+        addRow('Lípidos', lip, 'g');
+        Object.entries(formulation.electrolytes || {}).forEach(([k,v])=>{ addRow(k.charAt(0).toUpperCase()+k.slice(1), v, k==='phosphorus'? 'mmol':'mEq'); });
+        Object.entries(formulation.additives || {}).forEach(([k,v])=>{ if(v.volume>0||v.required>0) addRow(k.replace(/_/g,' '), v, k==='carnitine'?'mg':(k==='insulin'||k==='heparin')?'UI':'ml'); });
+        addRow('Água Estéril', formulation.water, 'ml');
+
+        y += 2;
+        doc.setFontSize(10); doc.setFont(undefined, 'bold');
+        line('Propriedades da Administração');
+        doc.setFontSize(9); doc.setFont(undefined, 'normal');
+        line(`Volume Total: ${this.formatValue(formulation.volume, 'ml', 0)}`);
+        line(`Osmolaridade: ${this.formatValue(formulation.osmolarity, 'mOsm/L', 0)}`);
+        if (preparationMap) { y += 3; doc.setFontSize(8); line('--- Mapa de Preparação ---'); y = doc.splitTextToSize(preparationMap, usableWidth).reduce((cy,l)=>{doc.text(l, margin, cy); return cy+4;}, y); }
+
+        if (formulation.warnings?.length) {
+            y += 2; doc.setFont(undefined,'bold'); doc.setTextColor(255,100,0); line('Avisos:'); doc.setTextColor(0,0,0); doc.setFont(undefined,'normal');
+            formulation.warnings.forEach(w=>line(`- ${w}`));
+        }
+        if (formulation.errors?.length) {
+            y += 2; doc.setFont(undefined,'bold'); doc.setTextColor(255,0,0); line('Erros:'); doc.setTextColor(0,0,0); doc.setFont(undefined,'normal');
+            formulation.errors.forEach(e=>line(`- ${e}`));
+        }
+        doc.addPage();
     }
     formatCompositionDetailsForPDF(formulation) {
         const details = [];
@@ -2891,6 +2891,15 @@ class NutriSoft {
         doc.text(`Volume: ${this.formatValue(bagVol, 'ml', 0)}`, textStartX, currentY); currentY += lineSpacingLabel;
         doc.text(`Validade: (Definir conforme protocolo)`, textStartX, currentY); currentY += lineSpacingLabel;
 
+        doc.setFontSize(7); doc.setFont(undefined, 'bold');
+        doc.text('Comp  Dose  Solução  Vol', textStartX, currentY); currentY += lineSpacingLabel;
+        doc.setFont(undefined,'normal');
+        const rows = [
+            ['AA', this.formatValue(formulation.proteins?.required,'g',0), formulation.proteins?.solution||'', this.formatValue(formulation.proteins?.volume,'ml',0)],
+            ['Glu', this.formatValue(formulation.glucose?.required,'g',0), formulation.glucose?.solution||'', this.formatValue(formulation.glucose?.volume,'ml',0)],
+            ['Líp', this.formatValue(formulation.lipids?.required,'g',0), formulation.lipids?.solution||'', this.formatValue(formulation.lipids?.volume,'ml',0)]
+        ];
+        rows.forEach(r=>{ doc.text(r.join('  '), textStartX, currentY); currentY+=lineSpacingLabel; });
 
         doc.setFontSize(7); doc.setFont(undefined, 'italic');
         doc.text('Conservar refrigerado. Proteger da luz.', textStartX, currentY);

--- a/script.js
+++ b/script.js
@@ -116,7 +116,43 @@ class DataManager {
             autoSaveIntervalMinutes: 5,
             accessLevel: 'basic',
             permissions: { exportData: false },
-            osmolarityLimits: { peripheral: 900, central: 1500 }
+            osmolarityLimits: { peripheral: 900, central: 1500 },
+            patientCategories: [
+                {
+                    id: 'cat-adult',
+                    name: 'Adulto',
+                    ageStart: 18,
+                    ageEnd: 99,
+                    substanceLimits: {
+                        nitrogen: { softUpper: 2, hardUpper: 2.5, unit: 'g/kg' },
+                        glucose_GIR: { softUpper: 5, hardUpper: 7, unit: 'mg/kg/min' },
+                        calcium: { hardUpper: 0.2, unit: 'mEq/kg' }
+                    }
+                }
+            ],
+            protocols: [
+                {
+                    id: 'proto-adult-standard',
+                    name: 'Adulto - Protocolo Padrão',
+                    patientCategoryId: 'cat-adult',
+                    dailyTemplates: [
+                        {
+                            day: 1,
+                            inputs: {
+                                nitrogen: 8,
+                                glucose: 150,
+                                lipids: 70,
+                                sodium: 80,
+                                potassium: 60,
+                                calcium: 9.3,
+                                magnesium: 16,
+                                phosphorus: 20,
+                                traceElements: 10
+                            }
+                        }
+                    ]
+                }
+            ]
         };
         const savedSettings = this.getData(this.settingsKey);
         return {
@@ -579,6 +615,10 @@ class NutriSoft {
             this.updateSolutionFormFieldsVisibility(event.target.value);
         });
 
+        document.getElementById('prescription-protocol')?.addEventListener('change', (e) => {
+            this.applyProtocol(e.target.value);
+        });
+
         const evolutionPatientSelect = document.getElementById('evolution-patient-select');
         evolutionPatientSelect?.addEventListener('change', () => {
              const patientId = evolutionPatientSelect.value;
@@ -838,8 +878,9 @@ class NutriSoft {
     }
     renderUIAllSections() { 
         console.log("NutriSoft.renderUIAllSections: Rendering all dynamic UI content...");
-        this.renderPatients(); 
-        this.renderPatientsList(); 
+        this.renderPatients();
+        this.renderProtocolOptions();
+        this.renderPatientsList();
         this.renderPrescriptionHistory();
         this.renderReports();
         this.renderPerformanceStats();
@@ -1002,7 +1043,46 @@ class NutriSoft {
                 <button data-action="delete" data-id="${patient.id}" class="table-action-btn text-red-600 hover:text-red-800 focus:outline-none focus:ring-2 focus:ring-red-500" title="Eliminar Doente"><i class="fas fa-trash"></i></button>
             `;
         });
-        this.checkAccessPermissions(); 
+        this.checkAccessPermissions();
+    }
+
+    renderProtocolOptions() {
+        const select = document.getElementById('prescription-protocol');
+        if (!select) {
+            console.warn("renderProtocolOptions: select not found.");
+            return;
+        }
+        const currentVal = select.value;
+        select.innerHTML = '<option value="">Nenhum</option>';
+        (this.settings.protocols || []).forEach(proto => {
+            const opt = document.createElement('option');
+            opt.value = proto.id;
+            opt.textContent = proto.name;
+            if (proto.id === currentVal) opt.selected = true;
+            select.appendChild(opt);
+        });
+    }
+
+    applyProtocol(protocolId) {
+        if (!protocolId) return;
+        const protocol = (this.settings.protocols || []).find(p => p.id === protocolId);
+        if (!protocol) return;
+        const template = protocol.dailyTemplates?.[0];
+        if (!template?.inputs) return;
+        const patient = this.getSelectedPatient();
+        const weight = patient?.weight || 0;
+        const inputs = template.inputs;
+        if (inputs.nitrogen) this.setInputValue('nitrogen-admin', inputs.nitrogen);
+        if (inputs.glucose) this.setInputValue('glucose-admin', inputs.glucose);
+        if (inputs.lipids) this.setInputValue('lipid-admin', inputs.lipids);
+        if (weight > 0) {
+            if (inputs.sodium) this.setInputValue('sodium-needs', (inputs.sodium / weight).toFixed(2));
+            if (inputs.potassium) this.setInputValue('potassium-needs', (inputs.potassium / weight).toFixed(2));
+            if (inputs.magnesium) this.setInputValue('magnesium-needs', (inputs.magnesium / weight).toFixed(2));
+            if (inputs.calcium) this.setInputValue('calcium-needs', (inputs.calcium / weight).toFixed(2));
+        }
+        if (inputs.phosphorus) this.setInputValue('phosphorus-needs', inputs.phosphorus);
+        if (inputs.traceElements) this.setInputValue('oligoelements-volume', inputs.traceElements);
     }
     renderPatientEvolution(patientId) { 
          const tbody = document.getElementById('patient-evolution-history');
@@ -1871,8 +1951,10 @@ class NutriSoft {
         }
 
         try {
+            const protocolId = document.getElementById('prescription-protocol')?.value || '';
             const formulation = {
-                patient: patient, 
+                patient: patient,
+                protocolId: protocolId,
                 volume: totalVolume, // Prescribed total volume
                 route: administrationRoute,
                 proteins: this.calculateProteins(patient),
@@ -2170,9 +2252,10 @@ class NutriSoft {
 
         const preparation = {
             preparationNumber: existingPrescription ? existingPrescription.preparationNumber : this.dataManager.getNextPreparationNumber(),
-            patientId: formulation.patient.id, 
-            patientName: formulation.patient.name, 
-            date: new Date().toISOString().split('T')[0], 
+            patientId: formulation.patient.id,
+            patientName: formulation.patient.name,
+            protocolId: formulation.protocolId || '',
+            date: new Date().toISOString().split('T')[0],
             volume: formulation.volume,
             osmolarity: formulation.osmolarity,
             preparationMap: this.generatePreparationMap(formulation), 
@@ -2422,6 +2505,7 @@ class NutriSoft {
         this.setInputValue('cacl2-solution', formulation.electrolytes?.calcium?.solution); 
         this.setInputValue('mgso4-solution', formulation.electrolytes?.magnesium?.solution);
         this.setInputValue('phosphorus-solution', formulation.electrolytes?.phosphorus?.solution);
+        this.setInputValue('prescription-protocol', formulation.protocolId || '');
     }
     printPrescription(originalIndex = null) { 
         console.log("NutriSoft.printPrescription: Preparing to print. Original Index:", originalIndex);

--- a/style.css
+++ b/style.css
@@ -1,4 +1,3 @@
-```css
 /* style.css - NutriSoft Custom Styles */
 
 /* --- Base & Typography --- */
@@ -303,4 +302,3 @@ body.modal-open {
         }
      }
 }
-```


### PR DESCRIPTION
## Summary
- add patient categories and protocols to default settings
- show protocol selection in prescription form
- populate protocol dropdown and apply protocol templates
- save selected protocol with each prescription
- fix style.css by removing markdown fences

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685be73399488330b0363a4efb1c90d1